### PR TITLE
Fixes a crash

### DIFF
--- a/websocket.js
+++ b/websocket.js
@@ -37,8 +37,9 @@ module.exports = (app) => {
     
             // This listens for messages Which are Emitted in public/js/main.js and then handles the UI to see the message
             socket.on('chatMessage', (msg) => {
+                if (typeof msg !== "string") return
                 io.to(user.room).emit('message', formatMessage(user.username, msg));
-            })
+            });
     
             socket.on('disconnect', () => {
                 for (const [key, value] of users.entries()) {


### PR DESCRIPTION
Fixes a crash when someone sends a object instead of a string as a chat message.
An attacker is able to open the developer tools and just send a payload with `socket.emit("chatMessage", {})`

This PR fixes the issue and makes the server ignore any payloads with a type other than string.